### PR TITLE
Make Ch. 2.1's code match final code

### DIFF
--- a/src/chapter_2_1.md
+++ b/src/chapter_2_1.md
@@ -97,7 +97,7 @@ And then define your `Vertex` type (it’s possible to use the same typename bec
 clash with types):
 
 ```rust
-#[derive(Vertex)]
+#[derive(Copy, Clone, Debug, Vertex)]
 #[vertex(sem = "VertexSemantics")]
 pub struct Vertex {
   #[allow(dead_code)]


### PR DESCRIPTION
In reference to issue #30 I have corrected the derive trait for Vertex that if using the code given in the page, failed to compile. It now matches the final code at the end of the chapter that does compile.